### PR TITLE
Wip/jremmet/support onoff

### DIFF
--- a/boards/mcimx95libra/board.c
+++ b/boards/mcimx95libra/board.c
@@ -304,6 +304,9 @@ void BOARD_InitHandlers(void) {
     /* Configure SWI handler */
     NVIC_EnableIRQ(BOARD_SWI_IRQn);
 
+    /* Enable BBNSM handler */
+    NVIC_EnableIRQ(BBNSM_IRQn);
+
     /* Enable GPC SM handler */
     NVIC_SetPriority(GPC_SM_REQ_IRQn, IRQ_PRIO_NOPREEMPT_VERY_HIGH);
     NVIC_EnableIRQ(GPC_SM_REQ_IRQn);

--- a/configs/mx95libra.cfg
+++ b/configs/mx95libra.cfg
@@ -344,6 +344,7 @@ LMM_2                       ALL
 RTC                         PRIV
 SENSOR_TEMP_ANA             ALL, test
 SYS                         ALL
+BUTTON                      NOTIFY
 
 # Resources
 


### PR DESCRIPTION
configs: mx95libra: add ONOFF button
    
    report the button over the protocols.
    
board: mcimx95libra: enable the BBNSM irq
    
    We are interested in the ONOFF button state.
    
    This was accidentally removed with the RTC removal
    Fixes: de05d4a91455 ("Adapt copied code to Libra i.MX 95")
