### PR TITLE
mx95libra: generate cold reset for systemreset by default

### DIFF
--- a/boards/mcimx95libra/sm/brd_sm.c
+++ b/boards/mcimx95libra/sm/brd_sm.c
@@ -393,13 +393,11 @@ void BRD_SM_ShutdownRecordSave(dev_sm_rst_rec_t shutdownRec) {
 /* Reset board                                                              */
 /*--------------------------------------------------------------------------*/
 int32_t BRD_SM_SystemReset(void) {
-    IOMUXC_SetPinMux(IOMUXC_PAD_WDOG_ANY__WDOG_ANY, 0U);
+    BOARD_WdogModeSet(BOARD_WDOG_MODE_COLD);
+    BOARD_WdogModeSet(BOARD_WDOG_MODE_TRIGGER);
 
-    /* Wait for PMIC to react */
-    SystemTimeDelay(1000U);
-
-    /* Fall back to warm reset of the device */
-    return DEV_SM_SystemReset();
+    /* This line should not be reached */
+    return SM_ERR_HARDWARE_ERROR;
 }
 
 /*--------------------------------------------------------------------------*/


### PR DESCRIPTION
Generate cold reset for systemreset by default. The reset command in SM was generating a warm reset before.