### PR TITLE
2025q3 update

### DIFF
--- a/boards/mcimx95libra/board.c
+++ b/boards/mcimx95libra/board.c
@@ -117,8 +117,8 @@ static board_uart_config_t const s_uartConfig = {
 void BOARD_ConfigMPU(void) {
 
     /* Disable code cache(ICache) and system cache(DCache) */
-    XCACHE_DisableCache(LPCAC_PC);
-    XCACHE_DisableCache(LPCAC_PS);
+    XCACHE_DisableCache(M33_CACHE_CTRLPC);
+    XCACHE_DisableCache(M33_CACHE_CTRLPS);
 
     /* NOTE: All TCRAM is non-cacheable regardless of MPU setting. */
 
@@ -235,8 +235,8 @@ void BOARD_ConfigMPU(void) {
     ARM_MPU_Enable(MPU_CTRL_PRIVDEFENA_Msk);
 
     /* Enable ICache and DCache */
-    XCACHE_EnableCache(LPCAC_PC);
-    XCACHE_EnableCache(LPCAC_PS);
+    XCACHE_EnableCache(M33_CACHE_CTRLPC);
+    XCACHE_EnableCache(M33_CACHE_CTRLPS);
 }
 
 /*--------------------------------------------------------------------------*/

--- a/boards/mcimx95libra/board.h
+++ b/boards/mcimx95libra/board.h
@@ -31,7 +31,7 @@
  */
 /** @{ */
 #define BOARD_TICK_PERIOD_MSEC  10U                       /*!< Tick period */
-#define BOARD_SWI_IRQn          Reserved110_IRQn          /*!< SWI IRQ */
+#define BOARD_SWI_IRQn          SWI_0_IRQn                /*!< SWI IRQ */
 #define BOARD_HAS_WDOG                                    /*!< Has a watchdog */
 #define BOARD_HAS_PMIC                                    /*!< Has a PMIC */
 #define BOARD_PMIC_RESUME_TICKS ((20U * 32768U) / 10000U) /*!< 2ms in 32K ticks */

--- a/configs/mx95libra.cfg
+++ b/configs/mx95libra.cfg
@@ -104,7 +104,7 @@ LM0         name="SM", rpc=none, boot=1, did=2, safe=feenv
 DFMT0:      sa=secure
 DFMT1:      sa=secure, pa=privileged
 OWNER:      perm=sec_rw, api=all
-ACCESS:     perm=sec_rw, api=all, mdid=none
+ACCESS:     perm=sec_rw, api=none, mdid=none
 TEST_MU:    perm=sec_rw
 
 EXEC:       perm=sec_rwx
@@ -115,39 +115,9 @@ MODE        msel=2, boot=1
 
 # API
 
-# Modified via PERF protocol
-CLK_A55MTRBUS               ALL
-CLK_ADC                     ALL
-CLK_BUSAON                  ALL
-CLK_BUSM7                   ALL
-CLK_BUSNETCMIX              ALL
-CLK_BUSWAKEUP               ALL
-CLK_CAMAPB                  ALL
-CLK_CAMAXI                  ALL
-CLK_CAMCM0                  ALL
-CLK_CAMISI                  ALL
-CLK_DISPAPB                 ALL
-CLK_DISPAXI                 ALL
-CLK_ELE                     ALL
-CLK_ENET                    ALL
-CLK_ENETPHYTEST200M         ALL
-CLK_ENETPHYTEST500M         ALL
-CLK_ENETPHYTEST667M         ALL
+# SM Clocks
+CLK_ADC			    ALL
 CLK_FRO                     ALL
-CLK_GPU                     ALL
-CLK_GPUAPB                  ALL
-CLK_HSIO                    ALL
-CLK_HSIOACSCAN480M          ALL
-CLK_HSIOACSCAN80M           ALL
-CLK_HSIOPCIETEST160M        ALL
-CLK_HSIOPCIETEST400M        ALL
-CLK_HSIOPCIETEST500M        ALL
-CLK_HSIOUSBTEST50M          ALL
-CLK_HSIOUSBTEST60M          ALL
-CLK_NOC                     ALL
-CLK_NOCAPB                  ALL
-CLK_NPU                     ALL
-CLK_NPUAPB                  ALL
 CLK_OSC24M                  ALL
 CLK_OSC32K                  ALL
 CLK_SYSPLL1_PFD0            ALL
@@ -159,14 +129,63 @@ CLK_SYSPLL1_PFD1_UNGATED    ALL
 CLK_SYSPLL1_PFD2            ALL
 CLK_SYSPLL1_PFD2_DIV2       ALL
 CLK_SYSPLL1_PFD2_UNGATED    ALL
-CLK_SYSPLL1_VCO             ALL
-CLK_TEMPSENSE_GPR_SEL       ALL
-CLK_TMU                     ALL
+CLK_SYSPLL1_VCO		    ALL
+CLK_TEMPSENSE_GPR_SEL	    ALL
+CLK_TMU			    ALL
+
+# Modified via PERF protocol
+CLK_A55			    ALL
+CLK_A55C0_GPR_SEL	    ALL
+CLK_A55C1_GPR_SEL	    ALL
+CLK_A55C2_GPR_SEL	    ALL
+CLK_A55C3_GPR_SEL	    ALL
+CLK_A55C4_GPR_SEL	    ALL
+CLK_A55C5_GPR_SEL	    ALL
+CLK_A55MTRBUS               ALL
+CLK_A55P_GPR_SEL	    ALL
+CLK_A55PERIPH		    ALL
+CLK_BUSAON                  ALL
+CLK_BUSM7                   ALL
+CLK_BUSNETCMIX              ALL
+CLK_BUSWAKEUP               ALL
+CLK_CAMAPB                  ALL
+CLK_CAMAXI                  ALL
+CLK_CAMCM0                  ALL
+CLK_CAMISI                  ALL
+CLK_DISPAPB                 ALL
+CLK_DISPAXI                 ALL
+CLK_DISPOCRAM		    ALL
+CLK_DRAM_GPR_SEL	    ALL
+CLK_DRAMALT		    ALL
+CLK_DRAMAPB		    ALL
+CLK_ELE                     ALL
+CLK_ENET                    ALL
+CLK_GPU                     ALL
+CLK_GPUAPB                  ALL
+CLK_HSIO                    ALL
+CLK_M33			    ALL
+CLK_M7			    ALL
+CLK_NOC                     ALL
+CLK_NOCAPB                  ALL
+CLK_NPU                     ALL
+CLK_NPUAPB                  ALL
 CLK_V2XPK                   ALL
 CLK_VPU                     ALL
 CLK_VPUAPB                  ALL
 CLK_VPUJPEG                 ALL
 CLK_WAKEUPAXI               ALL
+
+# Test CLocks
+CLK_ENETPHYTEST200M	    ALL
+CLK_ENETPHYTEST500M	    ALL
+CLK_ENETPHYTEST667M         ALL
+CLK_HSIOACSCAN480M          ALL
+CLK_HSIOACSCAN80M           ALL
+CLK_HSIOPCIETEST160M        ALL
+CLK_HSIOPCIETEST400M        ALL
+CLK_HSIOPCIETEST500M        ALL
+CLK_HSIOUSBTEST50M          ALL
+CLK_HSIOUSBTEST60M          ALL
 
 # Resources
 


### PR DESCRIPTION
This pr updates the libra i.MX 95 board with all necessary changes as described in the RN:

Must
- Move BOARD_SWI_IRQn definition to use SWI_0_IRQn (SM-277)
- On MX95, renamed LPCAC_PC to M33_CACHE_CTRLPC and LPCAC_PS to M33_CACHE_CTRLPS. (SM-277)

Recommended
- SM-269: Add device error log

Other
- SM-263: Add monitor delay command

This gets the 95 libra board to (at least) a bootable state (tested with lf-6.12.34 based BSP)