### PR TITLE
Introduce .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+root = true
+[*.{c,h}]
+charset = utf-8
+indent_size = 4
+indent_style = space
+max_line_length = 100
+trim_trailing_whitespace = true
+[Makefile]
+indent_size = 8
+indent_style = tab
+[*.md]
+indent_size = 4
+indent_style = space
+[*.{xml,tex}]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
Since NXP governs the style of the project, the best thing we can do is follow the style. Since NXP does not provide any help to automatically set editor setting to appropriate values, introduce a config that helps editors figure out which indentation to use. Reference: [1]

[1] https://editorconfig.org/