### PR TITLE
mx95libra: Change definition of DATA for secure AP agent

### DIFF
--- a/configs/mx95libra.cfg
+++ b/configs/mx95libra.cfg
@@ -420,7 +420,7 @@ DFMT1:      sa=secure, pa=privileged
 OWNER:      perm=sec_rw, api=all
 
 EXEC:       perm=sec_rwx
-DATA:       perm=rw
+DATA:       perm=sec_rw
 
 # Start/Stop (mSel=0)
 


### PR DESCRIPTION
This is based on commit
f89ee974177e ("SM-289: Change definition of DATA for secure AP agent."), secure AP should have secure access.